### PR TITLE
Fixes code spacing issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,5 @@ plugins:
   - jekyll-sitemap
   - jekyll-mentions
   - jemoji
-markdown: kramdown
-kramdown:
-   syntax_highlighter_opts:
-      disable : true
+markdown: GFM
 title: Lab Exercises


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 00

Switches the markdown processor to GFM. Fixes the issue with kramdown inserting a space at the beginning of every line in indented code blocks. Doesn't impact the approach of backspacing the code withing the "```" brackets.

So the following still renders just fine:

    ```
   code is only indented three spaces. 
    ```

Changes proposed in this pull request:

-
-
-